### PR TITLE
chore(release): v0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@lagoni/go-nats-template",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@lagoni/go-nats-template",
-			"version": "0.4.0",
+			"version": "0.4.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@asyncapi/generator-filters": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lagoni/go-nats-template",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Go NATS template for the AsyncAPI generator.",
 	"keywords": [
 		"asyncapi",


### PR DESCRIPTION
Version bump in package.json for release [v0.4.1](https://github.com/jonaslagoni/go-nats-template/releases/tag/v0.4.1)